### PR TITLE
Relax python 3.11.15 -> 3.10.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ tqdm>=4.66.1
 hydra-core>=1.3.2
 iopath>=0.1.10
 pillow>=9.4.0
-git+https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git@main#egg=sam2_realtime
+git+https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git@relax_python_3_10#egg=sam2_realtime

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ tqdm>=4.66.1
 hydra-core>=1.3.2
 iopath>=0.1.10
 pillow>=9.4.0
-git+https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git@relax_python_3_10#egg=sam2_realtime
+git+https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git@main#egg=sam2_realtime

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ tqdm>=4.66.1
 hydra-core>=1.3.2
 iopath>=0.1.10
 pillow>=9.4.0
--e .
+git+https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git@main#egg=sam2_realtime

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     license=LICENSE,
     packages=find_packages(),
     install_requires=REQUIRED_PACKAGES,
-    python_requires=">=3.11.10",
+    python_requires=">=3.10",
     ext_modules=get_extensions(),
     cmdclass={"build_ext": BuildExtension.with_options(no_python_abi_suffix=True)},
 )

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,10 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
+# Set the CUDA architecture list
+os.environ["TORCH_CUDA_ARCH_LIST"] = "8.0 8.6+PTX 8.7 9.0 9.0a"
+
 from setuptools import find_packages, setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
@@ -53,7 +57,7 @@ setup(
     license=LICENSE,
     packages=find_packages(),
     install_requires=REQUIRED_PACKAGES,
-    python_requires=">=3.10",
+    python_requires=">=3.10.15",
     ext_modules=get_extensions(),
     cmdclass={"build_ext": BuildExtension.with_options(no_python_abi_suffix=True)},
 )


### PR DESCRIPTION
Also substitutes "-e ." in requirements.txt for a pip package install from the git repo -
This triggers the compilation of required cuda extensions upon install.

TORCH_CUDA_ARCH_LIST also added in setup.py so not needed in dockerfile/env