### PR TITLE
fix: update point coords scaling for mask

### DIFF
--- a/sam2_realtime/sam2_tensor_predictor.py
+++ b/sam2_realtime/sam2_tensor_predictor.py
@@ -14,8 +14,6 @@ from tqdm import tqdm
 from sam2_realtime.modeling.sam2_base import NO_OBJ_SCORE, SAM2Base
 from sam2_realtime.utils.misc import concat_points, fill_holes_in_mask_scores, load_video_frames
 
-from sam2_realtime.utils.transforms import SAM2Transforms
-
 class SAM2TensorPredictor(SAM2Base):
     """The predictor class to handle user interactions and manage inference states."""
 


### PR DESCRIPTION
This fixes the point coord scaling to match to kijai segment anything 2 point coords computed for the model.

Using sample image, the coordinates computed by both nodes were:

```
kijai:  tensor([[[716.4031, 219.1440]]], device='cuda:0')
realtime:  tensor([[[716., 219.]]], device='cuda:0')
```