### PR TITLE
Fix node install from conda environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
 ## Install ComfyUI-SAM2-Realtime
-
+Clone the repo
 ```
 cd custom_nodes
 git clone https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git
 cd ComfyUI-SAM2-Realtime
+```
+
+Install requirements
+#### Linux
+```
+pip install -r requirements.txt
+pip install .
+```
+
+#### Windows**
+Use the `--no-build-isolation` flag when using conda on Windows to preserve env variables 
+```
 pip install -r requirements.txt
 pip install . --no-build-isolation
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ## Install ComfyUI-SAM2-Realtime
-Clone the repo
 ```
 cd custom_nodes
 git clone https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git

--- a/README.md
+++ b/README.md
@@ -4,18 +4,7 @@ Clone the repo
 cd custom_nodes
 git clone https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git
 cd ComfyUI-SAM2-Realtime
-```
-
-Install requirements
-#### Linux
-```
 pip install -r requirements.txt
 pip install .
 ```
-
-#### Windows**
-Use the `--no-build-isolation` flag when using conda on Windows to preserve env variables 
-```
-pip install -r requirements.txt
-pip install . --no-build-isolation
-```
+- On Windows conda environments `pip install . --no-build-isolation` may be needed to inherit system path variables

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+## Install ComfyUI-SAM2-Realtime
+
+```
+cd custom_nodes
+git clone https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git
+cd ComfyUI-SAM2-Realtime
+pip install -r requirements.txt
+pip install . --no-build-isolation
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ tqdm>=4.66.1
 hydra-core>=1.3.2
 iopath>=0.1.10
 pillow>=9.4.0
-git+https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git@main#egg=sam2_realtime

--- a/sam2_realtime/pyproject.toml
+++ b/sam2_realtime/pyproject.toml
@@ -1,0 +1,2 @@
+[project]
+name = "sam2_realtime"


### PR DESCRIPTION
This change resolves an issue when installing the node in conda environments on windows. 

Specifically, `git+https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git@main#egg=sam2_realtime` in requirements.txt does not receive system environment variables at runtime the same way as `pip install . --no-build-isolation` does. This change improves compatibility with ComfyUI-Manager so that it can be installed in all environments. 

- Adds **pyproject.toml** to sam2_realtime folder, which replaces `git+https://github.com/pschroedl/ComfyUI-SAM2-Realtime.git@main#egg=sam2_realtime` more effectively

The change can be validated by removing the `sam2_realtime` package, then `pip install .` and running a SAM 2 workflow in ComfyUI :
```
pip uninstall sam2_realtime
cd custom_nodes\ComfyUI-SAM2-Realtime
pip install . 
# --no-build-isolation is optional for some runtime environments
```
